### PR TITLE
Remove redundant classifier preventing PyPI publishing, as `package-mode = False` already handles this.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ authors = ["hasansezertasan <hasansezertasan@gmail.com>"]
 license = "MIT"
 readme = "README.md"
 maintainers = ["hasansezertasan <hasansezertasan@gmail.com>"]
-classifiers = ["Private :: Do not Upload"]
 package-mode = false
 
 


### PR DESCRIPTION
Remove redundant classifier preventing PyPI publishing, as `package-mode = False` already handles this.