### PR TITLE
ci: upload coverage to Codecov

### DIFF
--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -21,4 +21,11 @@ jobs:
           SESSION_SECRET_KEY: ci-test-key
         # Floor ratchets up only — never down. Current actual: ~73%.
         # Bump this when sustained coverage exceeds the floor by 5+ points.
-        run: uv run pytest --cov=app --cov-report=term-missing --cov-fail-under=70
+        run: uv run pytest --cov=app --cov-report=term-missing --cov-report=xml --cov-fail-under=70
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,7 +298,6 @@ Planned features:
   - Unit tests for models and views
   - Add test fixtures for users, sequences, and templates
   - Add CI workflow for running tests on push/PR
-  - Add code coverage reporting to CI
 - Daily Routine (auto-instantiated sequences)
 - Instant Tasks (standalone tasks outside sequences)
 - Docker deployment to Docker Hub

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > Experimental - Every dev needs to build a todo app...
 
 [![Code style: djlint](https://img.shields.io/badge/html%20style-djlint-blue.svg)](https://www.djlint.com)
+[![codecov](https://codecov.io/gh/hasansezertasan/not-just-a-todo-app/branch/main/graph/badge.svg)](https://codecov.io/gh/hasansezertasan/not-just-a-todo-app)
 
 ## Table of Contents
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 1%
+        threshold: 0.1%
     patch:
       default:
         target: 80%

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: true
+
+ignore:
+  - "tests/**"
+  - "src/app/db/migrations/**"


### PR DESCRIPTION
## Summary

- Emit `coverage.xml` from existing pytest run; upload via `codecov/codecov-action@v5`.
- Add `codecov.yml` — project target `auto` with 1% threshold, patch target 80%; ignore `tests/**` and Alembic migrations.
- Add Codecov badge to README.
- Drop "code coverage reporting to CI" from CLAUDE.md Planned section.

## Notes

- Public repo → tokenless OIDC upload works on first push; no `CODECOV_TOKEN` needed.
- Floor `--cov-fail-under=70` retained as ratchet; Codecov adds *delta* enforcement (regression catch) on top.
- Badge populates after first successful upload to `main`.

## Test plan

- [ ] CI runs `Tests & Coverage` job green
- [ ] `coverage.xml` artifact uploads to Codecov (check Actions log)
- [ ] Codecov posts PR comment with diff coverage
- [ ] README badge renders after merge to main

## Summary by Sourcery

Integrate Codecov coverage reporting into the test workflow and update project metadata accordingly.

Build:
- Configure pytest in the CI workflow to emit an XML coverage report and upload it to Codecov using the official GitHub Action.

Documentation:
- Add a Codecov coverage badge to the README and update CLAUDE.md to reflect that coverage reporting is now part of CI.