### PR TITLE
fix(tests): deterministic token tamper test

### DIFF
--- a/tests/test_token_service.py
+++ b/tests/test_token_service.py
@@ -23,7 +23,13 @@ def test_sign_and_verify_roundtrip(app: Flask) -> None:
 def test_tampered_token_rejected(app: Flask) -> None:
     with app.app_context():
         token = token_service.sign(7, salt="password-reset")
-        tampered = token[:-1] + ("A" if token[-1] != "A" else "B")
+        # Flip a char inside the signature segment, away from the final
+        # base64url char — the terminal char of a 20-byte HMAC encodes
+        # only 4 real bits + 2 padding bits, so naive last-char swaps
+        # can collide on padding and decode unchanged.
+        sig_start = token.rindex(".") + 1
+        mid = sig_start + (len(token) - sig_start) // 2
+        tampered = token[:mid] + ("A" if token[mid] != "A" else "B") + token[mid + 1 :]
         with pytest.raises(TokenError, match="invalid"):
             token_service.verify(tampered, salt="password-reset", max_age_seconds=60)
 


### PR DESCRIPTION
## Summary

- `test_tampered_token_rejected` flaked on CI run [25666477872](https://github.com/hasansezertasan/not-just-a-todo-app/actions/runs/25666477872/job/75340150295?pr=54) with random seed `3422067125`.
- Root cause: itsdangerous signs with HMAC-SHA1 (20 bytes → 27 base64url chars). The final char encodes only 4 real bits plus 2 padding bits the decoder ignores, so swapping the last char against `A`/`B` can mutate only padding and decode to the same signature — `BadSignature` never raised.
- Fix: mutate a middle char of the signature segment instead, so the swap always alters real signature bits.

## Test plan

- [x] `uv run pytest tests/test_token_service.py` — 4 passed
- [x] `SESSION_SECRET_KEY=ci-test-key uv run pytest tests/test_token_service.py --randomly-seed=3422067125` — reproduces the original CI ordering and passes

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a flaky test in `test_tampered_token_rejected` that failed on CI due to a subtle issue with base64url encoding. The test was tampering with the last character of a signed token, but because HMAC-SHA1 signatures (20 bytes) encode to 27 base64url characters where the final character only encodes 4 real bits plus 2 padding bits, swapping the last character could sometimes result in an identical decoded signature. The fix modifies the test to tamper with a character in the middle of the signature segment instead, ensuring that real signature bits are always altered and the `BadSignature` exception is consistently raised.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `tests/test_token_service.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->