### PR TITLE
ci: ignore unpatched Flask-Security-Too advisory in pip-audit

### DIFF
--- a/.github/workflows/check-security.yml
+++ b/.github/workflows/check-security.yml
@@ -39,8 +39,7 @@ jobs:
         # yet, and this app does not use Flask-Security-Too / WebAuthn — it
         # authenticates via Flask-Login. Revisit when a fix ships.
         run: >-
-          uv run --with pip-audit pip-audit --skip-editable
-          --ignore-vuln GHSA-f66q-9rf6-8795
+          uv run --with pip-audit pip-audit --skip-editable --ignore-vuln GHSA-f66q-9rf6-8795
   trivy:
     runs-on: ubuntu-24.04
     needs: pip-audit

--- a/.github/workflows/check-security.yml
+++ b/.github/workflows/check-security.yml
@@ -34,7 +34,13 @@ jobs:
       - name: Audit installed packages for known CVEs
         # --skip-editable: the current project installs as editable under
         # `uv sync` and has no PyPI release to audit — only its deps matter.
-        run: uv run --with pip-audit pip-audit --skip-editable
+        # --ignore-vuln GHSA-f66q-9rf6-8795: Flask-Security-Too WebAuthn
+        # reauthentication freshness bypass (medium). No patched release exists
+        # yet, and this app does not use Flask-Security-Too / WebAuthn — it
+        # authenticates via Flask-Login. Revisit when a fix ships.
+        run: >-
+          uv run --with pip-audit pip-audit --skip-editable
+          --ignore-vuln GHSA-f66q-9rf6-8795
   trivy:
     runs-on: ubuntu-24.04
     needs: pip-audit


### PR DESCRIPTION
## Summary

The `pip-audit` job in `check-security.yml` started failing after **GHSA-f66q-9rf6-8795** was published (2026-07-07) — a medium-severity WebAuthn reauthentication freshness bypass affecting `Flask-Security-Too` `>=5.8.0, <=5.8.1`.

There is **no patched release**, so upgrading cannot resolve it. The dependency is pinned at `5.8.1` in `pyproject.toml` but is **not imported or used anywhere** in the app — authentication is handled via Flask-Login, and there is no `flask_security` / `webauthn` usage.

## Change

Added `--ignore-vuln GHSA-f66q-9rf6-8795` to the `pip-audit` step, documented inline with the rationale and a note to revisit when a fix ships. The ignore is scoped to this specific advisory ID, so any other CVE (including a future one in the same package) still fails the build.

## Verification

Ran the updated command locally: `No known vulnerabilities found, 1 ignored` (exit `0`).